### PR TITLE
NSNumber比较大小方法错误导导致KDJ指标出现Nan的bug

### DIFF
--- a/BTC-Kline/BTC_K线图/KLine/Model/KLineModel/Y_KLineModel.m
+++ b/BTC-Kline/BTC_K线图/KLine/Model/KLineModel/Y_KLineModel.m
@@ -14,7 +14,7 @@
 - (NSNumber *)RSV_9
 {
     if (!_RSV_9) {
-        if(self.NineClocksMinPrice == self.NineClocksMaxPrice) {
+        if([self.NineClocksMinPrice compare:self.NineClocksMaxPrice] == NSOrderedSame) {
             _RSV_9 = @100;
         } else {
             _RSV_9 = @((self.Close.floatValue - self.NineClocksMinPrice.floatValue) * 100 / (self.NineClocksMaxPrice.floatValue - self.NineClocksMinPrice.floatValue));


### PR DESCRIPTION
NSNumber比较大小方法错误,导致KDJ指标出现Nan的bug